### PR TITLE
Handle backticked API references in markdown (including generics)

### DIFF
--- a/Tests/PortToTripleSlash/TestData/Generics/MyGenericType`1.xml
+++ b/Tests/PortToTripleSlash/TestData/Generics/MyGenericType`1.xml
@@ -9,7 +9,7 @@
       <format type="text/markdown">
   <![CDATA[
 ## Remarks
-Contains the nested class <xref:MyNamespace.MyGenericType%601.Enumerator>.
+The `MyGenericType<T>` type contains the nested class <xref:MyNamespace.MyGenericType%601.Enumerator>.
       ]]></format>
     </remarks>
   </Docs>

--- a/Tests/PortToTripleSlash/TestData/Generics/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Generics/SourceExpected.cs
@@ -3,7 +3,7 @@
 namespace MyNamespace
 {
     /// <summary>This is the MyGenericType{T} class summary.</summary>
-    /// <remarks>Contains the nested class <see cref="MyNamespace.MyGenericType{T}.Enumerator" />.</remarks>
+    /// <remarks>The <see cref="MyGenericType{T}" /> type contains the nested class <see cref="MyNamespace.MyGenericType{T}.Enumerator" />.</remarks>
     // Original MyGenericType<T> class comments with information for maintainers, must stay.
     public class MyGenericType<T>
     {


### PR DESCRIPTION
The `System.Buffers` library contains markdown remarks with backticked references to APIs that need to be converted to `<see cref>` tags, including some that are generic types. With the existing PR you have open from your branch plus this change, I can successfully backport the docs for `System.Buffers`, with the generic APIs handled.

/cc @carlossanlop